### PR TITLE
v2 対応漏れ修正

### DIFF
--- a/docs/en/authentication.md
+++ b/docs/en/authentication.md
@@ -13,7 +13,7 @@ title: v2
 -->
 
 ```:bash
-https://api.hokusai.app/v2/{network}/nft/{contractVersion/{contractAddress}/mint?key={apiKey}
+https://mumbai.hokusai.app/v2/{network}/nft/{contractVersion/{contractAddress}/mint?key={apiKey}
 ```
 
 <!--
@@ -22,9 +22,10 @@ title: v1
 -->
 
 ```:bash
-https://api.hokusai.app/v1/nfts/{contractAddress}/mint?key={apiKey}
+https://mumbai.hokusai.app/v1/nfts/{contractAddress}/mint?key={apiKey}
 ```
 
 <!-- type: tab-end -->
 
 All endpoints must include the `key` parameter with the API key.
+See [Endpoint](endpoint.md) for more information on Endpoints.

--- a/docs/en/authentication.md
+++ b/docs/en/authentication.md
@@ -13,7 +13,7 @@ title: v2
 -->
 
 ```:bash
-https://api.hokusai.app/v2/nft/{contractVersion/{contractAddress}/mint?key={apiKey}
+https://api.hokusai.app/v2/{network}/nft/{contractVersion/{contractAddress}/mint?key={apiKey}
 ```
 
 <!--

--- a/docs/en/authentication.md
+++ b/docs/en/authentication.md
@@ -13,7 +13,7 @@ title: v2
 -->
 
 ```:bash
-https://mumbai.hokusai.app/v2/{network}/nft/{contractVersion/{contractAddress}/mint?key={apiKey}
+https://mumbai.hokusai.app/v2/{network}/nft/{contractVersion/{contractId}/mint?key={apiKey}
 ```
 
 <!--
@@ -22,7 +22,7 @@ title: v1
 -->
 
 ```:bash
-https://mumbai.hokusai.app/v1/nfts/{contractAddress}/mint?key={apiKey}
+https://mumbai.hokusai.app/v1/nfts/{contractId}/mint?key={apiKey}
 ```
 
 <!-- type: tab-end -->

--- a/docs/en/get-started.md
+++ b/docs/en/get-started.md
@@ -100,8 +100,8 @@ Edit `.env` and set the variables. Note you don't need to set the `WALLET_PRIVAT
 WALLET_PRIVATE_KEY = "your-private-key"
 #API key for nft.storage
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
-#Contract Network (this is mock, please set "mumbai")
-CONTRACT_NETWORK = "mumbai"
+#Contract Network (this is mock, please set "polygon-mumbai")
+CONTRACT_NETWORK = "polygon-mumbai"
 #Hokusai API key
 HOKUSAI_API_KEY = "your-hokusai-api-key"
 #Hokusai Contract Version
@@ -212,8 +212,8 @@ Set your private key to `WALLET_PRIVATE_KEY` in `.env`.
 WALLET_PRIVATE_KEY = "your-private-key"
 #API key for nft.storage
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
-#Contract Network (this is mock, please set "mumbai")
-CONTRACT_NETWORK = "mumbai"
+#Contract Network (this is mock, please set "polygon-mumbai")
+CONTRACT_NETWORK = "polygon-mumbai"
 #Hokusai API key
 HOKUSAI_API_KEY = "your-hokusai-api-key"
 #Hokusai Contract Version

--- a/docs/en/network.md
+++ b/docs/en/network.md
@@ -3,9 +3,9 @@
 Hokusai v2 supports the following networks.
 Include the name of the network where you created your contracts in the API path parameter.
 
-| `{network}` | Network Name    |
-|-------------|-----------------|
-| `polygon`   | Polygon Mainnet |
-| `mumbai`    | Polygon Testnet |
+| `{network}`         | Network Name    |
+|---------------------|-----------------|
+| `polygon-mainnet`   | Polygon Mainnet |
+| `polygon-mumbai`    | Polygon Testnet |
 
 Other networks will be supported soon !

--- a/docs/ja/authentication.md
+++ b/docs/ja/authentication.md
@@ -14,7 +14,7 @@ title: v2
 -->
 
 ```:bash
-https://api.hokusai.app/v2/nft/{contractVersion/{contractAddress}/mint?key={apiKey}
+https://api.hokusai.app/v2/{network}/nft/{contractVersion/{contractAddress}/mint?key={apiKey}
 ```
 
 <!--

--- a/docs/ja/authentication.md
+++ b/docs/ja/authentication.md
@@ -14,7 +14,7 @@ title: v2
 -->
 
 ```:bash
-https://api.hokusai.app/v2/{network}/nft/{contractVersion/{contractAddress}/mint?key={apiKey}
+https://mumbai.hokusai.app/v2/{network}/nft/{contractVersion/{contractAddress}/mint?key={apiKey}
 ```
 
 <!--
@@ -23,10 +23,11 @@ title: v1
 -->
 
 ```:bash
-https://api.hokusai.app/v1/nfts/{contractAddress}/mint?key={apiKey}
+https://mumbai.hokusai.app/v1/nfts/{contractAddress}/mint?key={apiKey}
 ```
 
 <!-- type: tab-end -->
 
 
 このように、全てのエンドポイントには、API Key を値として持つ `key` パラメータの指定が必要となります。
+エンドポイントの詳細については[エンドポイント](endpoint.md)をご覧ください。

--- a/docs/ja/authentication.md
+++ b/docs/ja/authentication.md
@@ -14,7 +14,7 @@ title: v2
 -->
 
 ```:bash
-https://mumbai.hokusai.app/v2/{network}/nft/{contractVersion/{contractAddress}/mint?key={apiKey}
+https://mumbai.hokusai.app/v2/{network}/nft/{contractVersion/{contractId}/mint?key={apiKey}
 ```
 
 <!--
@@ -23,7 +23,7 @@ title: v1
 -->
 
 ```:bash
-https://mumbai.hokusai.app/v1/nfts/{contractAddress}/mint?key={apiKey}
+https://mumbai.hokusai.app/v1/nfts/{contractId}/mint?key={apiKey}
 ```
 
 <!-- type: tab-end -->

--- a/docs/ja/get-started.md
+++ b/docs/ja/get-started.md
@@ -103,8 +103,8 @@ $ cp .env.sample .env
 WALLET_PRIVATE_KEY = "your-private-key"
 #nft.storage API Keyを入力します。
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
-#ContractをデプロイしたNetworkを入力します(これはモックなので、"mumbai"と入力してください。)
-CONTRACT_NETWORK = "mumbai"
+#ContractをデプロイしたNetworkを入力します(これはモックなので、"polygon-mumbai"と入力してください。)
+CONTRACT_NETWORK = "polygon-mumbai"
 #Hokusai API Keyを入力します。
 HOKUSAI_API_KEY = "your-hokusai-api-key"
 #Hokusai Contract IDを入力します。
@@ -221,8 +221,8 @@ NFTを送信するには送信元アカウントの署名が必要になりま�
 WALLET_PRIVATE_KEY = "your-private-key"
 #nft.storage API Keyを入力します。
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
-#ContractをデプロイしたNetworkを入力します(これはモックなので、"mumbai"と入力してください。)
-CONTRACT_NETWORK = "mumbai"
+#ContractをデプロイしたNetworkを入力します(これはモックなので、"polygon-mumbai"と入力してください。)
+CONTRACT_NETWORK = "polygon-mumbai"
 #Hokusai API Keyを入力します。
 HOKUSAI_API_KEY = "your-hokusai-api-key"
 #Hokusai Contract IDを入力します。

--- a/docs/ja/network.md
+++ b/docs/ja/network.md
@@ -3,9 +3,9 @@
 Hokusai v2では、以下のネットワークに対応しています。  
 APIのパスパラメータに自身が発行したネットワーク名を含めてください。
 
- | `{network}` | ネットワーク名  |
- |-------------|-----------------|
- | `polygon`   | Polygon Mainnet |
- | `mumbai`    | Polygon Testnet |
+ | `{network}`         | ネットワーク名      |
+ |---------------------|-----------------|
+ | `polygon-mainnet`   | Polygon Mainnet |
+ | `polygon-mumbai`    | Polygon Testnet |
 
 これら以外のネットワークにも近日対応予定です！


### PR DESCRIPTION
## 関連リンク(Slack, Notion)や GitHub Issue

- https://monobundle-hq.slack.com/archives/C0293KBUX7H/p1647583063449569

## やったこと

- Authenticationのページのpath paramにnetworkを追加
- path paramに含むnetworkを polygon-{mainnet|mumbai} の形式に変更

## 動作確認

- 変更が正しいか
- 他に抜けがないか
