### PR TITLE
マルチチェーン対応で追加される対応チェーンを追加

### DIFF
--- a/docs/en/authentication.md
+++ b/docs/en/authentication.md
@@ -13,7 +13,7 @@ title: v2
 -->
 
 ```:bash
-https://mumbai.hokusai.app/v2/{network}/nft/{contractVersion/{contractId}/mint?key={apiKey}
+https://api.hokusai.app/v2/{network}/nft/{contractVersion/{contractId}/mint?key={apiKey}
 ```
 
 <!--
@@ -22,7 +22,7 @@ title: v1
 -->
 
 ```:bash
-https://mumbai.hokusai.app/v1/nfts/{contractId}/mint?key={apiKey}
+https://api.hokusai.app/v1/nfts/{contractId}/mint?key={apiKey}
 ```
 
 <!-- type: tab-end -->

--- a/docs/en/burn.md
+++ b/docs/en/burn.md
@@ -14,6 +14,4 @@ Burn history is [here](https://polygonscan.com/address/0x00000000000000000000000
 
 ## How to burn NFT in Hokusai
 
-You can learn how to burn NFT in [Hokusai Get Started](docs/en/get-started.md). This tutorial provides some code for you to get started with Hokusai.
-
-
+You can learn how to burn NFT in [Hokusai Get Started](get-started.md#transfer-an-nft). This tutorial provides some code for you to get started with Hokusai.

--- a/docs/en/discord-membership.md
+++ b/docs/en/discord-membership.md
@@ -43,6 +43,8 @@ Edit `.env` and set the variables. Note you **don't** need to set the `WALLET_PR
 WALLET_PRIVATE_KEY = ""
 # Your nft.storage API Key.
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
+#Contract Network
+CONTRACT_NETWORK = "the-network-your-deployed-contract"
 # Your Hokusai API Key.
 HOKUSAI_API_KEY = "your-hokusai-api-key"
 # Your Hokusai Contract ID.

--- a/docs/en/discord-membership.md
+++ b/docs/en/discord-membership.md
@@ -43,7 +43,7 @@ Edit `.env` and set the variables. Note you **don't** need to set the `WALLET_PR
 WALLET_PRIVATE_KEY = ""
 # Your nft.storage API Key.
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
-#Contract Network
+# Contract Network
 CONTRACT_NETWORK = "the-network-your-deployed-contract"
 # Your Hokusai API Key.
 HOKUSAI_API_KEY = "your-hokusai-api-key"

--- a/docs/en/endpoint.md
+++ b/docs/en/endpoint.md
@@ -1,18 +1,10 @@
 # Endpoint
-Hokusai is sending requests to the following endpoint. The base endpoint is:
+Hokusai is sending requests to the following endpoint. The base domain is:
 ```
-testnet: https://mumbai.hokusai.app  
-mainnet: https://polygon.hokusai.app  
+https://api.hokusai.app  
 ```
 
 Currently the Hokusai provides the following endpoints.
-
-If you using the Mumbai testnet, change the baseUrl of `src/getNft.ts` and `src/mintNft.ts`'s to "https://mumbai.hokusai.app".
-
-
-```
-https://mumbai.hokusai.app
-```
 
 The endpoint varies from version to version and the current default is v2.  
 The supported version differs for each smart contract, please check the version information on the email sent when the smart contract was created.

--- a/docs/en/endpoint.md
+++ b/docs/en/endpoint.md
@@ -25,7 +25,7 @@ title: v2
 |Endpoint|Description|
 |--|--|
 |[`GET /v2/{network}/nft/{contractVer}/{contractId}/{tokenId}`](../../reference/swagger-v2.yaml#get-information-of-the-nft)|Get NFT information|
-|[`POST /v2/{network}/nft/{contractVer}/{contractId}/mint`](../../reference/swagger-v2.yaml#mints-new-nft)|[Mint](glossary.md#Mint) an NFT|
+|[`POST /v2/{network}/nft/{contractVer}/{contractId}/mint`](../../reference/swagger-v2.yaml#mints-new-nft)|[Mint](glossary.md#Mint) NFTs|
 |[`POST /v2/{network}/nft/{contractVer}/{contractId}/transfer`](../../reference/swagger-v2.yaml#transfer-a-nft-with-meta-transaction)|Transfer an NFT|
 |[`GET /v2/{network}/nft/{contractVer}/{contractId}/{tokenId}/royalty`](../../reference/swagger-v2.yaml#get-royalty-of-the-nft)|Get a royalty of a specific NFT|
 |[`POST /v2/{network}/nft/{contractVer}/{contractId}/{tokenId}/royalty`](../../reference/swagger-v2.yaml#set-royalty-to-the-nft)|Set a royalty of a specific NFT|

--- a/docs/en/get-started.md
+++ b/docs/en/get-started.md
@@ -54,15 +54,7 @@ At this point, the account you've just created does not exist on the Polygon net
     
     ![custom_rpc.png](https://stoplight.io/api/v1/projects/cHJqOjg0NjEy/images/wVrrFHw5p3M)
     
-3. Fill out the fields with information below. For `New RPC URL`, choose one of the RPCs on the table and use another if it fails to connect to the network.
-
-    Property | Polygon Mainnet | Mumbai Testnet
-    ---------|----------|---------
-    Network Name | Polygon Mainnet | Mumbai Testnet
-    New RPC URL | https://polygon-rpc.com | https://rpc-mumbai.matic.today or <br>https://matic-mumbai.chainstacklabs.com or <br> https://rpc-mumbai.maticvigil.com or <br> https://matic-testnet-archive-rpc.bwarelabs.com
-    Chain ID | 137 | 80001
-    Currency (Optional) | MATIC | MATIC
-    Block Explorer URL (Optional) | https://polygonscan.com | https://mumbai.polygonscan.com
+3. Fill out the fields with information below. For `New RPC URL`, choose one of the RPCs on the table and use another if it fails to connect to the network.　This information can be found on the [network(chain)](network.md#rpc-infomations) page. This time you will use `polygon-mumbai` information.
     
     ![new_network_mainnet.png](https://stoplight.io/api/v1/projects/cHJqOjg0NjEy/images/ZmYEkZY00fM)
     

--- a/docs/en/get-started.md
+++ b/docs/en/get-started.md
@@ -100,7 +100,7 @@ Edit `.env` and set the variables. Note you don't need to set the `WALLET_PRIVAT
 WALLET_PRIVATE_KEY = "your-private-key"
 #API key for nft.storage
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
-#Contract Network (this is mock, please set "polygon-mumbai")
+#Contract Network (please set "polygon-mumbai" in this time)
 CONTRACT_NETWORK = "polygon-mumbai"
 #Hokusai API key
 HOKUSAI_API_KEY = "your-hokusai-api-key"
@@ -212,7 +212,7 @@ Set your private key to `WALLET_PRIVATE_KEY` in `.env`.
 WALLET_PRIVATE_KEY = "your-private-key"
 #API key for nft.storage
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
-#Contract Network (this is mock, please set "polygon-mumbai")
+#Contract Network (please set "polygon-mumbai" in this time)
 CONTRACT_NETWORK = "polygon-mumbai"
 #Hokusai API key
 HOKUSAI_API_KEY = "your-hokusai-api-key"

--- a/docs/en/mint-batchmint.md
+++ b/docs/en/mint-batchmint.md
@@ -77,8 +77,8 @@ import fetch from "node-fetch";
 import mintBody from "./mint.json";
 require("dotenv").config();
 const env = process.env
-const baseUrl = "https://mumbai.hokusai.app";
-const network = "polygon-mumbai" // or polygon-mainnet
+const baseUrl = "https://api.hokusai.app";
+const network = "polygon-mumbai" // or other networks
 mintNft(
   baseUrl, 
   network,
@@ -118,7 +118,7 @@ func main() {
   apiKey := os.Getenv("HOKUSAI_API_KEY")
   contractVer := os.Getenv("HOKUSAI_CONTRACT_VERSION")
   contractId := os.Getenv("HOKUSAI_CONTRACT_ID")
-  baseUrl := "https://mumbai.hokusai.app"
+  baseUrl := "https://api.hokusai.app"
   network := "polygon-mumbai"
 
   raw, err := ioutil.ReadFile("./batchmint.json")
@@ -376,13 +376,9 @@ func MintNft(
 
 ## Verify that the issued NFT is on the network
 
-The NFT issued this time should be on either of the following networks.
+You can check the NFT issued this time from Block Explorer.
 
-Select the URL of the one you have chosen and fly to the Polygonscan website.
-
-- Mumbai testnet：[https://mumbai.polygonscan.com](https://mumbai.polygonscan.com/)
-
-- Polygon mainnet：[https://polygonscan.com](https://polygonscan.com/)
+If you are using `polygon-mumbai` as sampled, you can check [Polygonscan](https://mumbai.polygonscan.com/) (Mumbai).
 
 ![13B6F730-CD85-4BED-AFE9-6BB1023B4D13_1_105_c.jpeg](https://stoplight.io/api/v1/projects/cHJqOjg0NjEy/images/GTUknOfQXT8)
 

--- a/docs/en/network.md
+++ b/docs/en/network.md
@@ -11,6 +11,11 @@ Include the name of the network where you created your contracts in the API path
 | `polygon-mumbai`    | Polygon Testnet                    |
 | `arbitrum-mainnet`  | Arbitrum Mainnet                   |
 | `arbitrum-rinkeby`  | Arbitrum Testnet                   |
+
+
+### To be determined
+| `{network}`         | Network Name                       |
+|---------------------|------------------------------------|
 | `binance-mainnet`   | Binance Mainnet                    |
 | `binance-testnet`   | Binance Testnet                    |
 | `astar-astar`       | Astar Mainnet (connedted Polkadot) |

--- a/docs/en/network.md
+++ b/docs/en/network.md
@@ -11,12 +11,12 @@ Include the name of the network where you created your contracts in the API path
 | `polygon-mumbai`    | Polygon Testnet                    |
 | `binance-mainnet`   | Binance Mainnet                    |
 | `binance-testnet`   | Binance Testnet                    |
-| `aster-aster`       | Aster Mainnet (connedted Polkadot) |
-| `aster-shiden`      | Aster Mainnet (connected Kusama)   |
-| `aster-shibuya`     | Aster Testnet (connected Tokyo)    |
+| `astar-astar`       | Astar Mainnet (connedted Polkadot) |
+| `astar-shiden`      | Astar Mainnet (connected Kusama)   |
+| `astar-shibuya`     | Astar Testnet (connected Tokyo)    |
 | `avalanche-mainnet` | Avalanche Mainnet                  |
 | `avalanche-fuji`    | Avalanche Testnet                  |
 | `arbitrum-mainnet`  | Arbitrum Mainnet                   |
 | `arbitrum-rinkeby`  | Arbitrum Testnet                   |
 
-Other networks will be supported soon !
+Other networks will be supported in the future !

--- a/docs/en/network.md
+++ b/docs/en/network.md
@@ -3,9 +3,20 @@
 Hokusai v2 supports the following networks.
 Include the name of the network where you created your contracts in the API path parameter.
 
-| `{network}`         | Network Name    |
-|---------------------|-----------------|
-| `polygon-mainnet`   | Polygon Mainnet |
-| `polygon-mumbai`    | Polygon Testnet |
+| `{network}`         | Network Name                       |
+|---------------------|------------------------------------|
+| `ethereum-mainnet`  | Ethereum Mainnet                   |
+| `ethereum-rinkeby`  | Ethereum Testnet                   |
+| `polygon-mainnet`   | Polygon Mainnet                    |
+| `polygon-mumbai`    | Polygon Testnet                    |
+| `binance-mainnet`   | Binance Mainnet                    |
+| `binance-testnet`   | Binance Testnet                    |
+| `aster-aster`       | Aster Mainnet (connedted Polkadot) |
+| `aster-shiden`      | Aster Mainnet (connected Kusama)   |
+| `aster-shibuya`     | Aster Testnet (connected Tokyo)    |
+| `avalanche-mainnet` | Avalanche Mainnet                  |
+| `avalanche-fuji`    | Avalanche Testnet                  |
+| `arbitrum-mainnet`  | Arbitrum Mainnet                   |
+| `arbitrum-rinkeby`  | Arbitrum Testnet                   |
 
 Other networks will be supported soon !

--- a/docs/en/network.md
+++ b/docs/en/network.md
@@ -9,6 +9,8 @@ Include the name of the network where you created your contracts in the API path
 | `ethereum-rinkeby`  | Ethereum Testnet                   |
 | `polygon-mainnet`   | Polygon Mainnet                    |
 | `polygon-mumbai`    | Polygon Testnet                    |
+| `arbitrum-mainnet`  | Arbitrum Mainnet                   |
+| `arbitrum-rinkeby`  | Arbitrum Testnet                   |
 | `binance-mainnet`   | Binance Mainnet                    |
 | `binance-testnet`   | Binance Testnet                    |
 | `astar-astar`       | Astar Mainnet (connedted Polkadot) |
@@ -16,7 +18,74 @@ Include the name of the network where you created your contracts in the API path
 | `astar-shibuya`     | Astar Testnet (connected Tokyo)    |
 | `avalanche-mainnet` | Avalanche Mainnet                  |
 | `avalanche-fuji`    | Avalanche Testnet                  |
-| `arbitrum-mainnet`  | Arbitrum Mainnet                   |
-| `arbitrum-rinkeby`  | Arbitrum Testnet                   |
+
+
+## RPC infomations
+
+RPC informations of each network.  
+Can be used to connect the wallet to the network.
+
+<!--
+type: tab
+title: Ethereum
+-->
+
+| Name             | RPC URL                      | Chain ID | Currency | Block Explorer URL           |
+|------------------|------------------------------|----------|----------|------------------------------|
+| Ethereum Mainnet | https://mainnet.infura.io/v3 | 1        | ETH      | https://etherscan.io	       |
+| Ethereum Rinkeby | https://rinkeby.infura.io/v3 | 4        | ETH      | https://rinkeby.etherscan.io |
+
+<!--
+type: tab
+title: Polygon
+-->
+
+| Name            | RPC URL                        | Chain ID | Currency | Block Explorer URL             |
+|-----------------|--------------------------------|----------|----------|--------------------------------|
+| Polygon Mainnet | https://polygon-rpc.com	       | 137      | MATIC    | https://polygonscan.com        |
+| Polygon Mumbai  | https://rpc-mumbai.matic.today | 80001    | MATIC    | https://mumbai.polygonscan.com |
+
+<!--
+type: tab
+title: Arbitrum
+-->
+
+| Name             | RPC URL                         | Chain ID | Currency | Block Explorer URL          |
+|------------------|---------------------------------|----------|----------|-----------------------------|
+| Arbitrum Mainnet | https://arb1.arbitrum.io/rpc	   | 42161    | ETH      | https://arbiscan.io         |
+| Arbitrum Rinkeby | https://rinkeby.arbitrum.io/rpc | 421611   | ETH      | https://testnet.arbiscan.io |
+
+<!--
+type: tab
+title: Binance
+-->
+
+| Name            | RPC URL                                        | Chain ID | Currency | Block Explorer URL          |
+|-----------------|------------------------------------------------|----------|----------|-----------------------------|
+| Binance Mainnet | https://bsc-dataseed.binance.org               | 56       | BNB      | https://bscscan.com         |
+| Binance Testnet | https://data-seed-prebsc-1-s1.binance.org:8545 | 97       | BNB      | https://testnet.bscscan.com |
+
+<!--
+type: tab
+title: Aster
+-->
+
+| Name            | RPC URL                                | Chain ID | Currency | Block Explorer URL         |
+|-----------------|----------------------------------------|----------|----------|----------------------------|
+| Aster           | https://rpc.astar.network:8545         | 592      | ASTR     | https://astar.subscan.io   |
+| Aster Shiden    | https://rpc.shiden.astar.network:8545  | 336      | SDN      | https://shiden.subscan.io  |
+| Aster Shibuya   | https://rpc.shibuya.astar.network:8545 | 81       | SBY      | https://shibuya.subscan.io |
+
+<!--
+type: tab
+title: Avalanche
+-->
+
+| Name              | RPC URL                                    | Chain ID | Currency | Block Explorer URL          |
+|-------------------|--------------------------------------------|----------|----------|-----------------------------|
+| Avalanche Mainnet | https://api.avax.network/ext/bc/C/rpc	     | 43114    | AVAX     | https://snowtrace.io        |
+| Avalanche Fuji    | https://api.avax-test.network/ext/bc/C/rpc | 43113    | AVAX     | https://testnet.explorer.avax.network |
+
+<!-- type: tab-end -->
 
 Other networks will be supported in the future !

--- a/docs/en/pricing.md
+++ b/docs/en/pricing.md
@@ -3,31 +3,4 @@
 Hokusai offers three different plans: Testnet, Business, and Enterprise.  
 Please compare the plans and choose the best one for your service.
 
- |  | **Testnet** | **Business** | **Enterprise** |
-| --- | --- | --- | --- |
-| **Basic charge(month)** | FREE | FREE | FREE |
-| **NFT mint upper limit** | UNLIMITED | UNLIMITED | UNLIMITED |
-| **NFT send upper limit** | UNLIMITED | UNLIMITED | UNLIMITED |
-| **GAS(Network fees)** | FREE | FREE | FREE |
-| **Original contract issuance fee** | (No original contract) | FREE | Contact sales |
-| **Mint NFT** | FREE | $8.0/tx | $8.0/tx |
-| **Send NFT** | FREE | $0.8/tx | $0.8/tx |
-| **Burn NFT** | FREE | $0.8/tx | $0.8/tx |
-| **Supported chains:** | Polygon(Testnet) | Polygon(Mainnet) | Polygon(Mainnet) |
-| | [**Get Started for Free**](https://0xhokusai.notion.site/Plolygon-Testnet-42bda92114ef4c28833e38fbc6fa04e0)| [**Submit**](https://0xhokusai.notion.site/Hokusai-API-API-Key-Registration-Form-API-a6d8118d416b41d88632396e3156cddb) | [**Contact sales**](https://hokusai.app/contact) |
-
-## Testnet plan
-
-Testnet plan is suitable for service verification and testing. All features are available for FREE. The available chain is Polygon Testnet.
-Click **[here](https://www.notion.so/Plolygon-Testnet-42bda92114ef4c28833e38fbc6fa04e0)** to register.
-
-## Business plan
-
-Business plan is suitable for services that are in the growth stage before they are released to the public for commercialization. The available chain is Polygon Mainnet.
-Click **[here](https://www.notion.so/Polygon-Mainnet-8b29f247de5b46e4900797ed4ab3818e)** to apply for use.
-
-## Enterprise plan
-
-Enterprise plan is available as a custom plan with a volume discount. We also provide a one-stop service for planning, technology, and legal services. To get started,Please contact us from **[here](https://hokusai.app/contact)**.
-
-
+Please see [here](https://hokusai.app/pricing) for prices.

--- a/docs/en/sample-app.md
+++ b/docs/en/sample-app.md
@@ -247,12 +247,13 @@ title: v2
 -->
 
 ```typescript
+const network = 'polygon-mumbai' // polygon testnet
 const contractVer = 'your-contract-version'
 const contractId = 'your-contract-id'
 const apiKey = 'your-api-key'
 
 result = await fetch(
-  `https://mumbai.hokusai.app/v2/nft/${contractVer}/${contractId}/transfer?key=${apiKey}`,
+  `https://api.hokusai.app/v2/${network}/nft/${contractVer}/${contractId}/transfer?key=${apiKey}`,
   {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/docs/ja/authentication.md
+++ b/docs/ja/authentication.md
@@ -14,7 +14,7 @@ title: v2
 -->
 
 ```:bash
-https://mumbai.hokusai.app/v2/{network}/nft/{contractVersion/{contractId}/mint?key={apiKey}
+https://api.hokusai.app/v2/{network}/nft/{contractVersion/{contractId}/mint?key={apiKey}
 ```
 
 <!--
@@ -23,7 +23,7 @@ title: v1
 -->
 
 ```:bash
-https://mumbai.hokusai.app/v1/nfts/{contractId}/mint?key={apiKey}
+https://api.hokusai.app/v1/nfts/{contractId}/mint?key={apiKey}
 ```
 
 <!-- type: tab-end -->

--- a/docs/ja/discord-membership.md
+++ b/docs/ja/discord-membership.md
@@ -44,13 +44,18 @@ $ cp .env.sample .env
 WALLET_PRIVATE_KEY = ""
 # nft.storage API Keyを入力します。
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
+#ContractをデプロイしたNetworkを入力します（今回は "polygon-mumbai" です)
+CONTRACT_NETWORK = "polygon-mumbai"
 # Hokusai API Keyを入力します。
 HOKUSAI_API_KEY = "your-hokusai-api-key"
+#Hokusai Contract IDを入力します。
+HOKUSAI_CONTRACT_VERSION = "your-contract-version"
 # Hokusai Contract IDを入力します。
 HOKUSAI_CONTRACT_ID = "your-contract-id"
 # Hokusai Contract Addressを入力します。
 HOKUSAI_CONTRACT_ADDRESS = "your-contract-address"
 ```
+
 
 ### 5. 必要なパッケージをインストールする
 

--- a/docs/ja/discord-membership.md
+++ b/docs/ja/discord-membership.md
@@ -44,11 +44,11 @@ $ cp .env.sample .env
 WALLET_PRIVATE_KEY = ""
 # nft.storage API Keyを入力します。
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
-#ContractをデプロイしたNetworkを入力します（今回は "polygon-mumbai" です)
+# ContractをデプロイしたNetworkを入力します（今回は "polygon-mumbai" です)
 CONTRACT_NETWORK = "polygon-mumbai"
 # Hokusai API Keyを入力します。
 HOKUSAI_API_KEY = "your-hokusai-api-key"
-#Hokusai Contract IDを入力します。
+# Hokusai Contract IDを入力します。
 HOKUSAI_CONTRACT_VERSION = "your-contract-version"
 # Hokusai Contract IDを入力します。
 HOKUSAI_CONTRACT_ID = "your-contract-id"

--- a/docs/ja/endpoint.md
+++ b/docs/ja/endpoint.md
@@ -2,17 +2,10 @@
 Hokusai では以下のベース URL に対してリクエストを送信します。
 
 ```
-testnet: https://mumbai.hokusai.app  
-mainnet: https://polygon.hokusai.app  
+https://api.hokusai.app  
 ```
 
 また、Hokusai では現在、以下のようなエンドポイントを提供しています。
-
-テストネットをご利用の場合は`src/getNft.ts`と`src/mintNft.ts`のbaseUrlを"https://mumbai.hokusai.app" に変更してください。
-
-```
-https://mumbai.hokusai.app
-```
 
 エンドポイントはバージョンごとに異なり、現在のデフォルトはv2です。  
 コントラクトごとに対応しているバージョンが異なるため、コントラクト作成時に送られてくるemailに記載されるバージョン情報をご確認ください。

--- a/docs/ja/get-started.md
+++ b/docs/ja/get-started.md
@@ -103,7 +103,7 @@ $ cp .env.sample .env
 WALLET_PRIVATE_KEY = "your-private-key"
 #nft.storage API Keyを入力します。
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
-#ContractをデプロイしたNetworkを入力します(これはモックなので、"polygon-mumbai"と入力してください。)
+#ContractをデプロイしたNetworkを入力します（今回は "polygon-mumbai" です)
 CONTRACT_NETWORK = "polygon-mumbai"
 #Hokusai API Keyを入力します。
 HOKUSAI_API_KEY = "your-hokusai-api-key"
@@ -146,8 +146,6 @@ $ curl https://dweb.link/ipfs/bafyreieaaqfof34kfqyvwe4arta6jsuwuauim4d24qo22ct2x
 ## 6. Hokusai を動かす
 
 Hokusai を動かす準備が整いました。
-
-テストネットをご利用の場合は`src/getNft.ts`と`src/mintNft.ts`のbaseUrlを"https://mumbai.hokusai.app" に変更してください。
 
 ### 6.1. NFT を発行する
 
@@ -221,7 +219,7 @@ NFTを送信するには送信元アカウントの署名が必要になりま�
 WALLET_PRIVATE_KEY = "your-private-key"
 #nft.storage API Keyを入力します。
 NFT_STORAGE_API_KEY = "your-nft-storage-api-key"
-#ContractをデプロイしたNetworkを入力します(これはモックなので、"polygon-mumbai"と入力してください。)
+#ContractをデプロイしたNetworkを入力します(今回は "polygon-mumbai" です)
 CONTRACT_NETWORK = "polygon-mumbai"
 #Hokusai API Keyを入力します。
 HOKUSAI_API_KEY = "your-hokusai-api-key"

--- a/docs/ja/get-started.md
+++ b/docs/ja/get-started.md
@@ -57,15 +57,8 @@ NFTを管理するためには、トークンを保持するアカウントが�
     
     ![custom_rpc.png](https://stoplight.io/api/v1/projects/cHJqOjg0NjEy/images/h0BhERcxMwI)
     
-3. それぞれのボックスに以下のように情報を入力してください。`新規 RPC URL`は、テーブルに記載のURLを一つ選んで入力してください。選択したURLでネットワークの接続に失敗した場合、別のURLを使ってみてください。
+3. それぞれのボックスに以下のように情報を入力してください。これらの情報は[ネットワーク（チェイン）](network.md##rpc接続情報)のページに掲載されています。<br>`新規 RPC URL`は、テーブルに記載のRPC URLを一つ選んで入力してください。選択したURLでネットワークの接続に失敗した場合、別のURLを使ってみてください。<br>今回は、`polygon-mumbai`の情報を使用します。
 
-    Property | Polygon Mainnet | Mumbai Testnet
-    ---------|----------|---------
-    ネットワーク名 | Polygon Mainnet | Mumbai Testnet
-    新規 RPC URL | https://polygon-rpc.com | https://rpc-mumbai.matic.today or <br>https://matic-mumbai.chainstacklabs.com or <br> https://rpc-mumbai.maticvigil.com or <br> https://matic-testnet-archive-rpc.bwarelabs.com
-    チェーン ID | 137 | 80001
-    通貨記号(オプション) | MATIC | MATIC
-    ブロックエクスプローラーのURL(オプション) | https://polygonscan.com | https://mumbai.polygonscan.com
     
     ![new_network_mainnet.png](https://stoplight.io/api/v1/projects/cHJqOjg0NjEy/images/unc7jEAbkIo)
     

--- a/docs/ja/mint-batchmint.md
+++ b/docs/ja/mint-batchmint.md
@@ -79,8 +79,8 @@ import fetch from "node-fetch";
 import mintBody from "./mint.json";
 require("dotenv").config();
 const env = process.env
-const baseUrl = "https://mumbai.hokusai.app";
-const network = "polygon-mumbai" // or polygon-mainnet
+const baseUrl = "https://api.hokusai.app";
+const network = "polygon-mumbai" // or other networks
 mintNft(
   baseUrl, 
   network,
@@ -120,7 +120,7 @@ func main() {
   apiKey := os.Getenv("HOKUSAI_API_KEY")
   contractVer := os.Getenv("HOKUSAI_CONTRACT_VERSION")
   contractId := os.Getenv("HOKUSAI_CONTRACT_ID")
-  baseUrl := "https://mumbai.hokusai.app"
+  baseUrl := "https://api.hokusai.app"
   network := "polygon-mumbai"
 
   raw, err := ioutil.ReadFile("./batchmint.json")
@@ -378,13 +378,9 @@ func MintNft(
 
 ## 発行されたNFTがネットワーク上にあるのを確認する
 
-今回発行したNFTは、以下のどちらかのネットワーク上にあるはずです。
+今回発行したNFTは、ブロックエクスプローラーから確認できます。
 
-自分で選んだ方のURLを選択してPolygonscanのwebサイトに飛んでください。
-
-- Mumbai テストネット：[https://mumbai.polygonscan.com](https://mumbai.polygonscan.com/)
-
-- Polygon メインネット：[https://polygonscan.com](https://polygonscan.com/)
+サンプルの通り `polygon-mumbai` を指定した場合は、[こちら](https://mumbai.polygonscan.com/)になります。
 
 ![13B6F730-CD85-4BED-AFE9-6BB1023B4D13_1_105_c.jpeg](https://stoplight.io/api/v1/projects/cHJqOjg0NjEy/images/GTUknOfQXT8)
 

--- a/docs/ja/network.md
+++ b/docs/ja/network.md
@@ -3,9 +3,20 @@
 Hokusai v2では、以下のネットワークに対応しています。  
 APIのパスパラメータに自身が発行したネットワーク名を含めてください。
 
- | `{network}`         | ネットワーク名      |
- |---------------------|-----------------|
- | `polygon-mainnet`   | Polygon Mainnet |
- | `polygon-mumbai`    | Polygon Testnet |
+| `{network}`         | ネットワーク名                         |
+|---------------------|------------------------------------|
+| `ethereum-mainnet`  | Ethereum Mainnet                   |
+| `ethereum-rinkeby`  | Ethereum Testnet                   |
+| `polygon-mainnet`   | Polygon Mainnet                    |
+| `polygon-mumbai`    | Polygon Testnet                    |
+| `binance-mainnet`   | Binance Mainnet                    |
+| `binance-testnet`   | Binance Testnet                    |
+| `aster-aster`       | Aster Mainnet (connedted Polkadot) |
+| `aster-shiden`      | Aster Mainnet (connected Kusama)   |
+| `aster-shibuya`     | Aster Testnet (connected Tokyo)    |
+| `avalanche-mainnet` | Avalanche Mainnet                  |
+| `avalanche-fuji`    | Avalanche Testnet                  |
+| `arbitrum-mainnet`  | Arbitrum Mainnet                   |
+| `arbitrum-rinkeby`  | Arbitrum Testnet                   |
 
 これら以外のネットワークにも近日対応予定です！

--- a/docs/ja/network.md
+++ b/docs/ja/network.md
@@ -11,12 +11,12 @@ APIのパスパラメータに自身が発行したネットワーク名を含�
 | `polygon-mumbai`    | Polygon Testnet                    |
 | `binance-mainnet`   | Binance Mainnet                    |
 | `binance-testnet`   | Binance Testnet                    |
-| `aster-aster`       | Aster Mainnet (connedted Polkadot) |
-| `aster-shiden`      | Aster Mainnet (connected Kusama)   |
-| `aster-shibuya`     | Aster Testnet (connected Tokyo)    |
+| `astar-astar`       | Astar Mainnet (connedted Polkadot) |
+| `astar-shiden`      | Astar Mainnet (connected Kusama)   |
+| `astar-shibuya`     | Astar Testnet (connected Tokyo)    |
 | `avalanche-mainnet` | Avalanche Mainnet                  |
 | `avalanche-fuji`    | Avalanche Testnet                  |
 | `arbitrum-mainnet`  | Arbitrum Mainnet                   |
 | `arbitrum-rinkeby`  | Arbitrum Testnet                   |
 
-これら以外のネットワークにも近日対応予定です！
+将来的には、これら以外のネットワークにも対応予定です！

--- a/docs/ja/network.md
+++ b/docs/ja/network.md
@@ -11,6 +11,10 @@ APIのパスパラメータに自身が発行したネットワーク名を含�
 | `polygon-mumbai`    | Polygon Testnet                    |
 | `arbitrum-mainnet`  | Arbitrum Mainnet                   |
 | `arbitrum-rinkeby`  | Arbitrum Testnet                   |
+
+### 近日対応予定
+| `{network}`         | ネットワーク名                         |
+|---------------------|------------------------------------|
 | `binance-mainnet`   | Binance Mainnet                    |
 | `binance-testnet`   | Binance Testnet                    |
 | `astar-astar`       | Astar Mainnet (connedted Polkadot) |

--- a/docs/ja/network.md
+++ b/docs/ja/network.md
@@ -9,6 +9,8 @@ APIのパスパラメータに自身が発行したネットワーク名を含�
 | `ethereum-rinkeby`  | Ethereum Testnet                   |
 | `polygon-mainnet`   | Polygon Mainnet                    |
 | `polygon-mumbai`    | Polygon Testnet                    |
+| `arbitrum-mainnet`  | Arbitrum Mainnet                   |
+| `arbitrum-rinkeby`  | Arbitrum Testnet                   |
 | `binance-mainnet`   | Binance Mainnet                    |
 | `binance-testnet`   | Binance Testnet                    |
 | `astar-astar`       | Astar Mainnet (connedted Polkadot) |
@@ -16,7 +18,75 @@ APIのパスパラメータに自身が発行したネットワーク名を含�
 | `astar-shibuya`     | Astar Testnet (connected Tokyo)    |
 | `avalanche-mainnet` | Avalanche Mainnet                  |
 | `avalanche-fuji`    | Avalanche Testnet                  |
-| `arbitrum-mainnet`  | Arbitrum Mainnet                   |
-| `arbitrum-rinkeby`  | Arbitrum Testnet                   |
+
+
+## RPC接続情報
+
+各ネットワークのRPC接続情報です。  
+Metamaskなどのウォレットとネットワークとの接続に使用できます。
+
+<!--
+type: tab
+title: Ethereum
+-->
+
+| ネットワーク名       | RPC URL                      | チェーンID | 通貨記号   | ブロックエクスプローラのURL        |
+|------------------|------------------------------|----------|----------|------------------------------|
+| Ethereum Mainnet | https://mainnet.infura.io/v3 | 1        | ETH      | https://etherscan.io	       |
+| Ethereum Rinkeby | https://rinkeby.infura.io/v3 | 4        | ETH      | https://rinkeby.etherscan.io |
+
+<!--
+type: tab
+title: Polygon
+-->
+
+| ネットワーク名      | RPC URL                        | チェーンID | 通貨記号   | ブロックエクスプローラのURL          |
+|-----------------|--------------------------------|----------|----------|--------------------------------|
+| Polygon Mainnet | https://polygon-rpc.com	       | 137      | MATIC    | https://polygonscan.com        |
+| Polygon Mumbai  | https://rpc-mumbai.matic.today | 80001    | MATIC    | https://mumbai.polygonscan.com |
+
+<!--
+type: tab
+title: Arbitrum
+-->
+
+| ネットワーク名       | RPC URL                         | チェーンID | 通貨記号   | ブロックエクスプローラのURL       |
+|------------------|---------------------------------|----------|----------|-----------------------------|
+| Arbitrum Mainnet | https://arb1.arbitrum.io/rpc	   | 42161    | ETH      | https://arbiscan.io         |
+| Arbitrum Rinkeby | https://rinkeby.arbitrum.io/rpc | 421611   | ETH      | https://testnet.arbiscan.io |
+
+<!--
+type: tab
+title: Binance
+-->
+
+| ネットワーク名      | RPC URL                                        | チェーンID | 通貨記号  | ブロックエクスプローラのURL        |
+|-----------------|------------------------------------------------|----------|----------|-----------------------------|
+| Binance Mainnet | https://bsc-dataseed.binance.org               | 56       | BNB      | https://bscscan.com         |
+| Binance Testnet | https://data-seed-prebsc-1-s1.binance.org:8545 | 97       | BNB      | https://testnet.bscscan.com |
+
+<!--
+type: tab
+title: Aster
+-->
+
+| ネットワーク名      | RPC URL                                | チェーンID | 通貨記号  | ブロックエクスプローラのURL       |
+|-----------------|----------------------------------------|----------|----------|----------------------------|
+| Aster           | https://rpc.astar.network:8545         | 592      | ASTR     | https://astar.subscan.io   |
+| Aster Shiden    | https://rpc.shiden.astar.network:8545  | 336      | SDN      | https://shiden.subscan.io  |
+| Aster Shibuya   | https://rpc.shibuya.astar.network:8545 | 81       | SBY      | https://shibuya.subscan.io |
+
+<!--
+type: tab
+title: Avalanche
+-->
+
+| ネットワーク名        | RPC URL                                    | チェーンID | 通貨記号  |  ブロックエクスプローラのURL       |
+|-------------------|--------------------------------------------|----------|----------|-----------------------------|
+| Avalanche Mainnet | https://api.avax.network/ext/bc/C/rpc	     | 43114    | AVAX     | https://snowtrace.io        |
+| Avalanche Fuji    | https://api.avax-test.network/ext/bc/C/rpc | 43113    | AVAX     | https://testnet.explorer.avax.network |
+
+<!-- type: tab-end -->
+
 
 将来的には、これら以外のネットワークにも対応予定です！

--- a/docs/ja/pricing.md
+++ b/docs/ja/pricing.md
@@ -3,27 +3,4 @@
 Hokusai では、テストネット・事業者向け・エンタープライズの３つのプランをご利用いただけます。  
 プランを比較して、サービスに最適なプランを選択してください。
 
- |  | **テストネット** | **事業者向け** | **エンタープライズ** |
-| --- | --- | --- | --- |
-| **ガス代(ネットワーク手数料)** | 無料 | 無料 | 無料 |
-| **独自コントラクト発行料** | 無料 | 無料 | お問い合わせください |
-| **NFTの送信** | 無料 | $0.8/件 | $0.8/件 |
-| **NFTの消却** | 無料 | $0.8/件 | $0.8/件 |
-| **NFTの発行** | 無料 | $8.0/件 | $8.0/件 |
-| **NFTの発行上限** | 無制限 | 無制限 | 無制限 |
-| **NFTの送信上限** | 無制限 | 無制限 | 無制限 |
-| **対応チェーン** | Polygon(Testnet) | Polygon(Mainnet) | Polygon(Mainnet) |
-| | [**無料で始める**](https://0xhokusai.notion.site/Plolygon-Testnet-42bda92114ef4c28833e38fbc6fa04e0)| [**登録する**](https://0xhokusai.notion.site/Hokusai-API-API-Key-Registration-Form-API-a6d8118d416b41d88632396e3156cddb) | [**問い合わせる**](https://hokusai.app/contact) |
-
-## テストネット
-
-テストネット版はサービスの検証・テストに適しています。 すべての機能が無料でご利用いただけます。 ご利用いただけるチェーンはPolygon Testnetです。 
-ご利用のお申込みは[**こちら**](https://0xhokusai.notion.site/Plolygon-Testnet-42bda92114ef4c28833e38fbc6fa04e0)
-
-## 事業者向け
-事業者向けプランは、事業化に向けて一般公開前の成長段階にあるサービスに適しています。ご利用いただけるチェーンはPolygon Mainnetです。   
-ご利用のお申込みは[**こちら**](https://0xhokusai.notion.site/Plolygon-Testnet-42bda92114ef4c28833e38fbc6fa04e0)
-
-## エンタープライズ
-エンタープライズ版は、ボリュームディスカウント・カスタムプランがございます。また、企画・技術・法務 のワンストップサービスを提供しています。まずは[**こちら**](https://hokusai.app/contact)からお問い合わせください。
-
+料金に関しては、[こちら](https://hokusai.app/jp/pricing)をご覧ください。

--- a/docs/ja/sample-app.md
+++ b/docs/ja/sample-app.md
@@ -259,12 +259,13 @@ title: v2
 -->
 
 ```typescript
+const network = 'polygon-mumbai' // polygon testnet
 const contractVer = 'your-contract-version'
 const contractId = 'your-contract-id'
 const apiKey = 'your-api-key'
 
 result = await fetch(
-  `https://mumbai.hokusai.app/v2/nft/${contractVer}/${contractId}/transfer?key=${apiKey}`,
+  `https://api.hokusai.app/v2/${network}/nft/${contractVer}/${contractId}/transfer?key=${apiKey}`,
   {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## 関連リンク(Slack, Notion)や GitHub Issue

- https://www.notion.so/0xhokusai/API-Docs-32e0ec789fb5463790fc5163e22f3081

## やったこと

- multichain対応で追加される対応チェーンのリストを更新
- 英語のmint endpointに関する説明を更新（BatchMint対応）

## その他

使ったsyntaxはdata-providerの[multichain対応で定義された名前](https://github.com/0xhokusai/hokusai-api-data-provider/blob/main/src/%40types/TargetNetwork.ts#L1-L15)を参考にしました。