### PR TITLE
Rename tokenUri property of mint body with tokenURI

### DIFF
--- a/reference/swagger-v2.yaml
+++ b/reference/swagger-v2.yaml
@@ -301,7 +301,7 @@ definitions:
         to:
           type: string
           description: Address to mint the NFT to
-        tokenUri:
+        tokenURI:
           type: string
           description: Metadata URI
   TransferNFT:


### PR DESCRIPTION
## 関連リンク(Slack, Notion)や GitHub Issue

- https://monobundle-hq.slack.com/archives/C0293KBUX7H/p1648201225610749
- https://docs.hokusai.app/docs/hokusai/b3A6NDQyMjg0MTY-mints-new-nft#request-body

## やったこと

v2のMintのリクエストボディにある`tokenUri`プロパティを`tokenURI`に修正

## 動作確認

Mintページ(en/ja)のリクエストボディがしっかり修正されているか確認